### PR TITLE
Add revalidate API for microCMS webhook

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,25 @@
+import { revalidateTag } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
+
+export async function POST(request: NextRequest) {
+  const signature = request.headers.get('x-microcms-signature');
+  const body = await request.text();
+
+  if (!signature || !process.env.MICROCMS_WEBHOOK_SECRET) {
+    return NextResponse.json({ message: 'Missing signature or secret' }, { status: 401 });
+  }
+
+  const expectedSignature = crypto
+    .createHmac('sha256', process.env.MICROCMS_WEBHOOK_SECRET)
+    .update(body)
+    .digest('hex');
+
+  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
+    return NextResponse.json({ message: 'Invalid signature' }, { status: 401 });
+  }
+
+  revalidateTag('microcms', { expire: 60 * 60 * 24 * 30 }); // 30 days
+
+  return NextResponse.json({ revalidated: true, now: Date.now() });
+}

--- a/lib/microcms.ts
+++ b/lib/microcms.ts
@@ -28,6 +28,9 @@ export async function getArticles() {
   return await client.get<ArticlesResponse>({
     endpoint: 'articles',
     queries: { limit: 100 },
+    customRequestInit: {
+      next: { tags: ['microcms'] },
+    },
   });
 }
 
@@ -38,5 +41,8 @@ export type Profile = {
 export async function getProfile() {
   return await client.get<Profile>({
     endpoint: 'profile',
+    customRequestInit: {
+      next: { tags: ['microcms'] },
+    },
   });
 }


### PR DESCRIPTION
## Summary
- Add `/api/revalidate` endpoint for microCMS webhook
- HMAC-SHA256 signature verification for security
- Use `revalidateTag` with cache tags

## Changes
| File | Change |
|------|--------|
| `app/api/revalidate/route.ts` | New - webhook endpoint |
| `lib/microcms.ts` | Add `customRequestInit` with tags |

## Environment Variables Required
```
MICROCMS_WEBHOOK_SECRET=<your-webhook-secret>
```

## microCMS Webhook Setup
- URL: `https://your-domain.com/api/revalidate`
- Header: `x-microcms-signature` (auto-generated by microCMS)

## Test plan
- [x] `npm run build` succeeds
- [ ] Webhook triggers revalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)