### PR TITLE
fix: Load PT Sans font from Google Fonts

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,14 @@
 import '../styles/globals.scss';
 import ParticleBackground from '@/components/ParticleBackground';
+import { PT_Sans } from 'next/font/google';
+
+const ptSans = PT_Sans({
+  weight: ['400', '700'],
+  style: ['normal', 'italic'],
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-pt-sans',
+});
 
 export default function RootLayout({
   children,
@@ -7,7 +16,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ja">
+    <html lang="ja" className={ptSans.variable}>
       <body>
         <ParticleBackground />
         {children}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -22,7 +22,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: 'PT Sans', sans-serif;
+  font-family: var(--font-pt-sans), 'PT Sans', sans-serif;
   font-style: italic;
   font-weight: bold;
   letter-spacing: 1pt;


### PR DESCRIPTION
## Summary
- `next/font/google`でPT Sansを読み込み
- iOSでフォントが適用されない問題を修正

## Test plan
- [ ] iOSのSafariでPT Sansフォントが適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)